### PR TITLE
initial commit for docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,0 @@
-node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:14.21.1-alpine
 
 WORKDIR /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:latest
+
+WORKDIR /
+
+COPY . .
+
+RUN npm install 
+
+CMD cat overlay.yaml | node bin.js

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+PLATFORM?=linux/amd64
+
+build:
+	docker buildx build --platform ${PLATFORM} -t overlay-cli .


### PR DESCRIPTION
This build effectively will enable this sort of use of the CLI 

```
docker run  --rm -ti  -v ${PWD}/basic.yml:/overlay.yaml overlay-cli
```

The idea is to be able to easily use overlay-cli in multiple platforms (linux, macos, win)  and multiple cpu arch (arm, amd).
Ideally we could use vercel/pkg but that means packaging up to 6 different binaries into a single CLI app. 

NOTE: While trying to build for platforms linux/arm/v7 llinux/arm64/v8 I found out that the official node image doesn't really work. Build was resulting in
```
 => ERROR [3/4] RUN npm install                                                                                                                                                                                   0.3s
------
 > [3/4] RUN npm install:
#0 0.266 exec /bin/sh: exec format error
```



Signed-off-by: jasmingacic <jasmin.gacic@gmail.com>