### PR TITLE
update the JSON Schema for overlays to match the latest spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To use, pipe in an Overlay definition and it'll output the result as YAML.
 **Example Overlay**
 
 ```yaml
-overlays: 1.0.0
+overlay: 1.0.0
 extends: https://petstore3.swagger.io/api/v3/openapi.json
 actions:
   - target: '$.paths'

--- a/overlays-test-suite/v1.0.0/all-actions.yml
+++ b/overlays-test-suite/v1.0.0/all-actions.yml
@@ -7,7 +7,7 @@ refs:
     two: {}
 
 input:
-  overlays: 1.0.0
+  overlay: 1.0.0
   extends: http://example.com
   actions:
     - target: $.*

--- a/overlays-test-suite/v1.0.0/remove-root.yml
+++ b/overlays-test-suite/v1.0.0/remove-root.yml
@@ -6,7 +6,7 @@ refs:
     one: 1
 
 input:
-  overlays: 1.0.0
+  overlay: 1.0.0
   extends: http://example.com
   actions:
     - target: '$'

--- a/overlays-test-suite/v1.0.0/where-empty-false.yml
+++ b/overlays-test-suite/v1.0.0/where-empty-false.yml
@@ -19,7 +19,7 @@ refs:
       /string: 'foo'
 
 input:
-  overlays: 1.0.0
+  overlay: 1.0.0
   extends: http://example.com
   actions:
     - target: $.paths.*

--- a/overlays-test-suite/v1.0.0/where-empty.yml
+++ b/overlays-test-suite/v1.0.0/where-empty.yml
@@ -19,7 +19,7 @@ refs:
       /string: 'foo'
 
 input:
-  overlays: 1.0.0
+  overlay: 1.0.0
   extends: http://example.com
   actions:
     - target: $.paths.*

--- a/overlays-test-suite/v1.0.0/where-not-only.yml
+++ b/overlays-test-suite/v1.0.0/where-not-only.yml
@@ -11,7 +11,7 @@ refs:
       bar: true
 
 input:
-  overlays: 1.0.0
+  overlay: 1.0.0
   extends: http://example.com
   actions:
     - target: $.*

--- a/overlays-test-suite/v1.0.0/where-not.yml
+++ b/overlays-test-suite/v1.0.0/where-not.yml
@@ -11,7 +11,7 @@ refs:
       bar: true
 
 input:
-  overlays: 1.0.0
+  overlay: 1.0.0
   extends: http://example.com
   actions:
     - target: $.*

--- a/overlays-test-suite/v1.0.0/where-target-not.yml
+++ b/overlays-test-suite/v1.0.0/where-target-not.yml
@@ -11,7 +11,7 @@ refs:
       bar: true
 
 input:
-  overlays: 1.0.0
+  overlay: 1.0.0
   extends: http://example.com
   actions:
     - target: '$.*'

--- a/overlays-test-suite/v1.0.0/where.yml
+++ b/overlays-test-suite/v1.0.0/where.yml
@@ -11,7 +11,7 @@ refs:
       bar: true
 
 input:
-  overlays: 1.0.0
+  overlay: 1.0.0
   extends: http://example.com
   actions:
     - target: $.*

--- a/overlays.schema.json
+++ b/overlays.schema.json
@@ -1,9 +1,9 @@
 {
   "$id": "https://github.com/OAI/Overlay-Specification/blob/main/versions/1.0.0.md",
-  "required": ["overlays", "actions"],
+  "required": ["overlay", "info", "actions"],
   "type": "object",
   "properties": {
-    "overlays": {
+    "overlay": {
       "type": "string",
       "description": "Version of the specification",
       "const": "1.0.0"
@@ -11,23 +11,51 @@
     "extends": {
       "type": "string"
     },
+    "info": {
+      "required": ["title", "version"],
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^x-": true
+      },
+      "additionalProperties": false
+    },
     "actions": {
       "type": "array",
       "description": "List of actions to take",
+      "minItems": 1,
       "items": {
-	"type": "object",
-	"required": ["target"],
-	"properties": {
-	  "target": {
-	    "type": "string"
-	  },
-	  "remove": {
-	    "type": "boolean",
-	    "const": true
-	  },
-	  "update": true
-	}
+        "type": "object",
+        "required": ["target"],
+        "properties": {
+          "target": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "remove": {
+            "type": "boolean",
+            "default": false
+          },
+          "update": true
+        },
+        "patternProperties": {
+          "^x-": true
+        },
+        "additionalProperties": false
       }
     }
-  }
+  },
+  "patternProperties": {
+    "^x-": true
+  },
+  "additionalProperties": false
 }

--- a/samples/apply-403-to-security.yml
+++ b/samples/apply-403-to-security.yml
@@ -1,4 +1,4 @@
-overlays: 1.0.0
+overlay: 1.0.0
 extends: https://petstore3.swagger.io/api/v3/openapi.json
 actions:
 - target: '$.paths.*[?(@.security)].responses'

--- a/samples/basic.yml
+++ b/samples/basic.yml
@@ -1,4 +1,4 @@
-overlays: 1.0.0
+overlay: 1.0.0
 extends: https://petstore3.swagger.io/api/v3/openapi.json
 actions:
   - target: '$.paths'

--- a/samples/only-user-tag.yml
+++ b/samples/only-user-tag.yml
@@ -1,4 +1,4 @@
-overlays: 1.0.0
+overlay: 1.0.0
 extends: https://petstore3.swagger.io/api/v3/openapi.json
 actions:
   - target: '$.paths.*'

--- a/samples/update-get-pets.overlay.yml
+++ b/samples/update-get-pets.overlay.yml
@@ -1,4 +1,4 @@
-overlays: 1.0.0
+overlay: 1.0.0
 extends: https://petstore.swagger.io/v2/swagger.json
 actions:
 - target: '$.paths."/pet/{petId}".get'

--- a/samples/x-internal.overlay.yml
+++ b/samples/x-internal.overlay.yml
@@ -1,4 +1,4 @@
-overlays: 1.0.0
+overlay: 1.0.0
 extends: ./x-internal.source.yml
 actions:
   - target: '$..[?(@["x-internal"])]'

--- a/split-into-overlay.js
+++ b/split-into-overlay.js
@@ -4,7 +4,7 @@ const jsonPointerToJsonPath = require('./json-pointer-to-json-path')
 const get = require('./get')
 
 module.exports = function splitIntoOverlay(input, {targets=[], fields=[], where=[]} = {}) {
-    let overlay = {overlays: '1.0.0'}
+    let overlay = {overlay: '1.0.0'}
     targets = Array.isArray(targets) ? targets : [targets]
     where = Array.isArray(where) ? where : [where]
     if(!targets.length)

--- a/split-into-overlay.test.js
+++ b/split-into-overlay.test.js
@@ -4,7 +4,7 @@ describe('splitIntoOverlay', () => {
     it('create an empty overlay definition by default', async () => {
         const overlay = splitIntoOverlay({})
         expect(overlay).toEqual({
-            overlays: '1.0.0'
+            overlay: '1.0.0'
         })
     })
 
@@ -17,7 +17,7 @@ describe('splitIntoOverlay', () => {
         }
         const overlay = splitIntoOverlay(input, {targets: '$.*'})
         expect(overlay).toEqual({
-            overlays: '1.0.0',
+            overlay: '1.0.0',
             actions: [{
                 target: '$["one"]',
                 update: {}
@@ -39,7 +39,7 @@ describe('splitIntoOverlay', () => {
         }
         const overlay = splitIntoOverlay(input, {targets: ['$.one', '$.two']})
         expect(overlay).toEqual({
-            overlays: '1.0.0',
+            overlay: '1.0.0',
             actions: [{
                 target: '$["one"]',
                 update: 1
@@ -60,7 +60,7 @@ describe('splitIntoOverlay', () => {
         }
         const overlay = splitIntoOverlay(input, {targets: '$.*'})
         expect(overlay).toEqual({
-            overlays: '1.0.0',
+            overlay: '1.0.0',
             actions: [
                 {
                     target: '$["one"]',
@@ -102,7 +102,7 @@ describe('splitIntoOverlay', () => {
             fields: ['description', 'summary'],
         })
         expect(overlay).toEqual({
-            overlays: '1.0.0',
+            overlay: '1.0.0',
             actions: [{
                 target: '$["paths"]["/foo"]["get"]',
                 update: {
@@ -143,7 +143,7 @@ describe('splitIntoOverlay', () => {
         })
 
         expect(overlay).toEqual({
-            overlays: '1.0.0',
+            overlay: '1.0.0',
             actions: [{
                 target: '$["paths"]["/foo"]["get"]',
                 update: {


### PR DESCRIPTION
This updates the JSON Schema and sample overlay files to match the latest state of the [Overlays Specification](https://github.com/OAI/Overlay-Specification/blob/main/versions/1.0.0.md).

Overview of the changes:
* renamed the top-level `overlays` keyword (plural) to `overlay` (singular)
* added the `info` object
* `actions` array must contain at least 1 item
* updated the actions schema
* added support for `x-` specification extensions
* disallow unknown keywords

Tested with `npm run test` and by running `cat <file> | node bin.js` locally.